### PR TITLE
Fixing bug where KeepAlive entity was not being cleared

### DIFF
--- a/src/main/java/com/rider/folly/json/Folly.java
+++ b/src/main/java/com/rider/folly/json/Folly.java
@@ -151,7 +151,8 @@ public class Folly {
             mutex.lock();
 
             httpPost.setURI(new URI(OperationType.KEEP_ALIVE.getAddress()));
-
+            httpPost.setEntity(new StringEntity(""));
+            
             keepAliveResponse = gson.fromJson(httpClient.execute(httpPost, responseHandler), KeepAliveResponse.class);
 
             if (keepAliveResponse.getStatus().equals(KeepAliveStatus.SUCCESS)) {


### PR DESCRIPTION
KeepAlive is reusing httpPost which needs the entity to be null or empty
